### PR TITLE
use 303 redirects instead of 301s

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -126,8 +126,8 @@ func TestPostCodeUpload(t *testing.T) {
 
 	mux.ServeHTTP(w, req)
 
-	if w.Code != 301 {
-		t.Fatalf("Status code is not 301, but %d", w.Code)
+	if w.Code != 303 {
+		t.Fatalf("Status code is not 303, but %d", w.Code)
 	}
 
 	if w.Header().Get("Location") != "/"+filename+"."+extension {
@@ -157,8 +157,8 @@ func TestPostCodeUploadWhitelistedHeader(t *testing.T) {
 
 	mux.ServeHTTP(w, req)
 
-	if w.Code != 301 {
-		t.Fatalf("Status code is not 301, but %d", w.Code)
+	if w.Code != 303 {
+		t.Fatalf("Status code is not 303, but %d", w.Code)
 	}
 }
 
@@ -287,8 +287,8 @@ func TestPostUpload(t *testing.T) {
 
 	mux.ServeHTTP(w, req)
 
-	if w.Code != 301 {
-		t.Fatalf("Status code is not 301, but %d", w.Code)
+	if w.Code != 303 {
+		t.Fatalf("Status code is not 303, but %d", w.Code)
 	}
 
 	if w.Header().Get("Location") != "/"+filename {

--- a/upload.go
+++ b/upload.go
@@ -103,7 +103,7 @@ func uploadPostHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Redirect(w, r, "/"+upload.Filename, 301)
+		http.Redirect(w, r, "/"+upload.Filename, 303)
 	}
 
 }
@@ -139,7 +139,7 @@ func uploadPutHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 
 func uploadRemote(c web.C, w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("url") == "" {
-		http.Redirect(w, r, "/", 301)
+		http.Redirect(w, r, "/", 303)
 		return
 	}
 
@@ -174,7 +174,7 @@ func uploadRemote(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Redirect(w, r, "/"+upload.Filename, 301)
+		http.Redirect(w, r, "/"+upload.Filename, 303)
 	}
 }
 


### PR DESCRIPTION
HTTP status code 301 is for a permanent redirect, which these are not.
Although 302 would work here in most browsers, it would not follow the
HTTP spec, so instead we use 303 which has a clearly and consistently
defined behavior in response to a POST or PUT request.