### PR TITLE
workaround chrome nonsense with CSP

### DIFF
--- a/server.go
+++ b/server.go
@@ -201,7 +201,7 @@ func main() {
 		"default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; referrer origin;",
 		"value of default Content-Security-Policy header")
 	flag.StringVar(&Config.fileContentSecurityPolicy, "filecontentsecuritypolicy",
-		"default-src 'none'; img-src 'self'; object-src 'self'; media-src 'self'; referrer origin;",
+		"default-src 'none'; img-src 'self'; object-src 'self'; media-src 'self'; style-src 'self' 'unsafe-inline'; referrer origin;",
 		"value of Content-Security-Policy header for file access")
 	flag.StringVar(&Config.xFrameOptions, "xframeoptions", "SAMEORIGIN",
 		"value of X-Frame-Options header")


### PR DESCRIPTION
Apparently the Chromium developers have decided that it was a good idea
for them to use inline styles on the image/PDF viewers in their browser.
I have no idea why they would think this, as it is not, but since this
causes breakage we allow unsafe-inline for styles on files.