### PR TITLE
support .tar.gz-style extensions

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -887,6 +887,24 @@ func TestPutAndSpecificDelete(t *testing.T) {
 	}
 }
 
+func TestExtension(t *testing.T) {
+	barename, extension := barePlusExt("test.jpg.gz")
+	if barename != "testjpg" {
+		t.Fatal("Barename was not testjpg, but " + barename)
+	}
+	if extension != "gz" {
+		t.Fatal("Extension was not gz, but " + extension)
+	}
+
+	barename, extension = barePlusExt("test.tar.gz")
+	if barename != "test" {
+		t.Fatal("Barename was not test, but " + barename)
+	}
+	if extension != "tar.gz" {
+		t.Fatal("Extension was not tar.gz, but " + extension)
+	}
+}
+
 func TestShutdown(t *testing.T) {
 	os.RemoveAll(Config.filesDir)
 	os.RemoveAll(Config.metaDir)

--- a/upload.go
+++ b/upload.go
@@ -322,20 +322,35 @@ func generateJSONresponse(upload Upload) []byte {
 	return js
 }
 
-var barePlusRe = regexp.MustCompile(`[^A-Za-z0-9\-]`)
+var bareRe = regexp.MustCompile(`[^A-Za-z0-9\-]`)
+var extRe = regexp.MustCompile(`[^A-Za-z0-9\-\.]`)
+var compressedExts = map[string]bool{
+	".bz2": true,
+	".gz":  true,
+	".xz":  true,
+}
+var archiveExts = map[string]bool{
+	".tar": true,
+}
 
 func barePlusExt(filename string) (barename, extension string) {
-
 	filename = strings.TrimSpace(filename)
 	filename = strings.ToLower(filename)
 
 	extension = path.Ext(filename)
 	barename = filename[:len(filename)-len(extension)]
+	if compressedExts[extension] {
+		ext2 := path.Ext(barename)
+		if archiveExts[ext2] {
+			barename = barename[:len(barename)-len(ext2)]
+			extension = ext2 + extension
+		}
+	}
 
-	extension = barePlusRe.ReplaceAllString(extension, "")
-	barename = barePlusRe.ReplaceAllString(barename, "")
+	extension = extRe.ReplaceAllString(extension, "")
+	barename = bareRe.ReplaceAllString(barename, "")
 
-	extension = strings.Trim(extension, "-")
+	extension = strings.Trim(extension, "-.")
 	barename = strings.Trim(barename, "-")
 
 	return


### PR DESCRIPTION
Some extensions actually consist of multiple parts, like .tar.gz, so we
should handle this properly instead of merging part of the extension
with the bare name. Right now only tar is allowed, but others can be
added easily.

Fixes #74.