### PR TITLE
Add ability to set arbitrary headers

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+type addheaders struct {
+	h       http.Handler
+	headers []string
+}
+
+func (a addheaders) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, header := range a.headers {
+		headerSplit := strings.SplitN(header, ": ", 2)
+		w.Header().Add(headerSplit[0], headerSplit[1])
+	}
+
+	a.h.ServeHTTP(w, r)
+}
+
+func AddHeaders(headers []string) func(http.Handler) http.Handler {
+	fn := func(h http.Handler) http.Handler {
+		return addheaders{h, headers}
+	}
+	return fn
+}

--- a/server_test.go
+++ b/server_test.go
@@ -52,6 +52,24 @@ func TestIndex(t *testing.T) {
 	}
 }
 
+func TestAddHeader(t *testing.T) {
+	Config.addHeaders = []string{"Linx-Test: It works!"}
+
+	mux := setup()
+	w := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux.ServeHTTP(w, req)
+
+	if w.Header().Get("Linx-Test") != "It works!" {
+		t.Fatal("Header 'Linx-Test: It works!' not found in index response")
+	}
+}
+
 func TestAuthKeys(t *testing.T) {
 	Config.authFile = "/dev/null"
 


### PR DESCRIPTION
This is useful if you want to add headers for things like HTTP Strict
Transport Security or HTTP Public Key Pinning.