### PR TITLE
Infer site URL from host and headers

### DIFF
--- a/fileserve.go
+++ b/fileserve.go
@@ -26,7 +26,7 @@ func fileServeHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	if !Config.allowHotlink {
 		referer := r.Header.Get("Referer")
 		u, _ := url.Parse(referer)
-		p, _ := url.Parse(Config.siteURL)
+		p, _ := url.Parse(getSiteURL(r))
 		if referer != "" && !sameOrigin(u, p) {
 			http.Redirect(w, r, Config.sitePath+fileName, 303)
 			return

--- a/headers.go
+++ b/headers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -24,4 +25,27 @@ func AddHeaders(headers []string) func(http.Handler) http.Handler {
 		return addheaders{h, headers}
 	}
 	return fn
+}
+
+func getSiteURL(r *http.Request) string {
+	if Config.siteURL != "" {
+		return Config.siteURL
+	} else {
+		u := &url.URL{}
+		u.Host = r.Host
+
+		if Config.sitePath != "" {
+			u.Path = Config.sitePath
+		}
+
+		if scheme := r.Header.Get("X-Forwarded-Proto"); scheme != "" {
+			u.Scheme = scheme
+		} else if Config.certFile != "" || (r.TLS != nil && r.TLS.HandshakeComplete == true) {
+			u.Scheme = "https"
+		} else {
+			u.Scheme = "http"
+		}
+
+		return u.String()
+	}
 }

--- a/pages.go
+++ b/pages.go
@@ -36,7 +36,7 @@ func pasteHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 }
 
 func apiDocHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	err := Templates["API.html"].ExecuteWriter(pongo2.Context{}, w)
+	err := Templates["API.html"].ExecuteWriter(pongo2.Context{"siteurl": getSiteURL(r)}, w)
 	if err != nil {
 		oopsHandler(c, w, r, RespHTML, "")
 	}

--- a/torrent.go
+++ b/torrent.go
@@ -37,7 +37,7 @@ func hashPiece(piece []byte) []byte {
 	return h.Sum(nil)
 }
 
-func createTorrent(fileName string, filePath string) ([]byte, error) {
+func createTorrent(fileName string, filePath string, r *http.Request) ([]byte, error) {
 	chunk := make([]byte, TORRENT_PIECE_LENGTH)
 
 	torrent := Torrent{
@@ -46,7 +46,7 @@ func createTorrent(fileName string, filePath string) ([]byte, error) {
 			PieceLength: TORRENT_PIECE_LENGTH,
 			Name:        fileName,
 		},
-		UrlList: []string{fmt.Sprintf("%sselif/%s", Config.siteURL, fileName)},
+		UrlList: []string{fmt.Sprintf("%sselif/%s", getSiteURL(r), fileName)},
 	}
 
 	f, err := os.Open(filePath)
@@ -89,7 +89,7 @@ func fileTorrentHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	encoded, err := createTorrent(fileName, filePath)
+	encoded, err := createTorrent(fileName, filePath, r)
 	if err != nil {
 		oopsHandler(c, w, r, RespHTML, "Could not create torrent.")
 		return

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -11,7 +11,7 @@ func TestCreateTorrent(t *testing.T) {
 	fileName := "server.go"
 	var decoded Torrent
 
-	encoded, err := createTorrent(fileName, fileName)
+	encoded, err := createTorrent(fileName, fileName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestCreateTorrent(t *testing.T) {
 func TestCreateTorrentWithImage(t *testing.T) {
 	var decoded Torrent
 
-	encoded, err := createTorrent("test.jpg", "static/images/404.jpg")
+	encoded, err := createTorrent("test.jpg", "static/images/404.jpg", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/upload.go
+++ b/upload.go
@@ -46,7 +46,7 @@ type Upload struct {
 }
 
 func uploadPostHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	if !strictReferrerCheck(r, Config.siteURL, []string{"Linx-Delete-Key", "Linx-Expiry", "Linx-Randomize", "X-Requested-With"}) {
+	if !strictReferrerCheck(r, getSiteURL(r), []string{"Linx-Delete-Key", "Linx-Expiry", "Linx-Randomize", "X-Requested-With"}) {
 		badRequestHandler(c, w, r)
 		return
 	}
@@ -94,7 +94,7 @@ func uploadPostHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		js := generateJSONresponse(upload)
+		js := generateJSONresponse(upload, r)
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.Write(js)
 	} else {
@@ -124,7 +124,7 @@ func uploadPutHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		js := generateJSONresponse(upload)
+		js := generateJSONresponse(upload, r)
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.Write(js)
 	} else {
@@ -133,7 +133,7 @@ func uploadPutHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fmt.Fprintf(w, Config.siteURL+upload.Filename)
+		fmt.Fprintf(w, getSiteURL(r)+upload.Filename)
 	}
 }
 
@@ -174,7 +174,7 @@ func uploadRemote(c web.C, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		js := generateJSONresponse(upload)
+		js := generateJSONresponse(upload, r)
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.Write(js)
 	} else {
@@ -308,9 +308,9 @@ func generateBarename() string {
 	return uniuri.NewLenChars(8, []byte("abcdefghijklmnopqrstuvwxyz0123456789"))
 }
 
-func generateJSONresponse(upload Upload) []byte {
+func generateJSONresponse(upload Upload, r *http.Request) []byte {
 	js, _ := json.Marshal(map[string]string{
-		"url":        Config.siteURL + upload.Filename,
+		"url":        getSiteURL(r) + upload.Filename,
 		"filename":   upload.Filename,
 		"delete_key": upload.Metadata.DeleteKey,
 		"expiry":     strconv.FormatInt(upload.Metadata.Expiry.Unix(), 10),


### PR DESCRIPTION
We can use the Host property of the request and the X-Forwarded-Proto to
infer the site URL. To reduce complexity, the path is not inferred, and
it is assumed that linx-server is running at /. If this is not the case,
the site URL must be manually configured; this is no different than it
was before.