### PR TITLE
Fix that custom sitename gets ignored

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -78,6 +78,8 @@ func renderTemplate(tpl *pongo2.Template, context pongo2.Context, r *http.Reques
 	if Config.siteName == "" {
 		parts := strings.Split(r.Host, ":")
 		context["sitename"] = parts[0]
+	} else {
+		context["sitename"] = Config.siteName
 	}
 
 	context["sitepath"] = Config.sitePath


### PR DESCRIPTION
Hello,

custom sitenames currently are just ignored.
Bug introduced at commit: https://github.com/andreimarcu/linx-server/commit/47a1aa6396565b7f5db5bd04a5ee5d36b4d399d4

Thanks,
Atrox