### PR TITLE
Remove unnecessary file processing in display.go

### DIFF
--- a/display.go
+++ b/display.go
@@ -39,12 +39,6 @@ func fileDisplayHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	extra := make(map[string]string)
 	lines := []string{}
 
-	file, _ := fileBackend.Open(fileName)
-	defer file.Close()
-
-	header := make([]byte, 512)
-	file.Read(header)
-
 	extension := strings.TrimPrefix(filepath.Ext(fileName), ".")
 
 	if strings.EqualFold("application/json", r.Header.Get("Accept")) {


### PR DESCRIPTION
There is no need to open the file here; nothing is done with the header
after it is read.