### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine
+
+RUN set -ex \
+        && apk add --no-cache --virtual .build-deps git mercurial \
+        && go get github.com/andreimarcu/linx-server \
+        && apk del .build-deps
+
+VOLUME ["/data/files", "/data/meta"]
+
+EXPOSE 8080
+USER nobody
+ENTRYPOINT ["/go/bin/linx-server", "-bind=0.0.0.0:8080", "-filespath=/data/files/", "-metapath=/data/meta/"]
+CMD ["-sitename=linx", "-allowhotlink"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ Run linx-server with the ```-certfile path/to/cert.file``` and ```-keyfile path/
 #### 3. Using the built-in http server
 Run linx-server normally.
 
+#### 4. Using Docker with the built-in http server
+First, build the image:
+```docker build -t linx-server .```
+
+You'll need some directories for the persistent storage. For the purposes of this example, we will use `/media/meta` and `/media/files`.
+
+Then, run it:
+```docker run -p 8080:8080 -v /media/meta:/data/meta -v /media/files:/data/files linx-server```
+
 
 Development
 -----------


### PR DESCRIPTION
This will build the binary directly in the image without a need to have Go installed locally.