### PR TITLE
Fix file upload for Internet Explorer

### DIFF
--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -43,7 +43,7 @@ Dropzone.options.dropzone = {
 	},
 	sending: function(file, xhr, formData) {
 		formData.append("randomize", document.getElementById("randomize").checked);
-		formData.append("expires", document.getElementById("expires").selectedOptions[0].value);
+		formData.append("expires", document.getElementById("expires").value);
 	},
 	success: function(file, resp) {
         file.fileActions.removeChild(file.progressElement);


### PR DESCRIPTION
`selectedOptions` is not available in Internet Explorer, use value instead.
See #108 