### PR TITLE
Fix max expiry when provided expiry is 0

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -450,7 +450,9 @@ func TestPostJSONUploadMaxExpiry(t *testing.T) {
 	mux := setup()
 	Config.maxExpiry = 300
 
-	testExpiries := []string{"86400", "-150"}
+	// include 0 to test edge case
+	// https://github.com/andreimarcu/linx-server/issues/111
+	testExpiries := []string{"86400", "-150", "0"}
 	for _, expiry := range testExpiries {
 		w := httptest.NewRecorder()
 

--- a/upload.go
+++ b/upload.go
@@ -349,7 +349,7 @@ func parseExpiry(expStr string) time.Duration {
 		if err != nil {
 			return time.Duration(Config.maxExpiry) * time.Second
 		} else {
-			if Config.maxExpiry > 0 && expiry > Config.maxExpiry {
+			if Config.maxExpiry > 0 && (expiry > Config.maxExpiry || expiry == 0) {
 				expiry = Config.maxExpiry
 			}
 			return time.Duration(expiry) * time.Second


### PR DESCRIPTION
Previously, we did not properly handle the case where the provided
expiry was zero and the max expiry was configured to be nonzero; add an
additional check to cover this case.

Fixes #111.