### PR TITLE
Fix files and meta permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN set -ex \
         && go get github.com/andreimarcu/linx-server \
         && apk del .build-deps
 
+RUN mkdir -p /data/files && mkdir -p /data/meta && chown -R 65534:65534 /data
+
 VOLUME ["/data/files", "/data/meta"]
 
 EXPOSE 8080


### PR DESCRIPTION
When running under docker-compose the volume changes the permissions by default to root but its avoided if the directory where it is mounted is created first with the correct owner.