### PR TITLE
Allow to paste images

### DIFF
--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -102,8 +102,18 @@ Dropzone.options.dropzone = {
 	previewsContainer: "#uploads",
 	parallelUploads: 5,
 	headers: {"Accept": "application/json"},
-	dictDefaultMessage: "Click or Drop file(s)",
+	dictDefaultMessage: "Click or Drop file(s) or Paste image",
 	dictFallbackMessage: ""
+};
+
+document.onpaste = function(event) {
+	var items = (event.clipboardData || event.originalEvent.clipboardData).items;
+	for (index in items) {
+		var item = items[index];
+		if (item.kind === "file") {
+			Dropzone.forElement("#dropzone").addFile(item.getAsFile());
+		}
+	}
 };
 
 // @end-license

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
         </div>
 
         <div id="dzone" class="dz-default dz-message">
-            <span>Click or Drop file(s)</span>
+            <span>Click or Drop file(s) or Paste image</span>
         </div>
 
         <div id="choices">


### PR DESCRIPTION
dropzone.js doesn't support pasting itself yet, so adding it externally and calling `.addFile()` to upload the pasted image.

I tested this on linux with firefox and chromium, I'm not able to test this in other browsers too, but I expect it to work at least in these browsers on other operating systems too.

Fixes #130