### PR TITLE
Fix broken page when file is missing

### DIFF
--- a/fileserve.go
+++ b/fileserve.go
@@ -38,8 +38,12 @@ func fileServeHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Referrer-Policy", Config.fileReferrerPolicy)
 
 	_, reader, err := storageBackend.Get(fileName)
-	if err != nil {
-		oopsHandler(c, w, r, RespAUTO, err.Error())
+	if err == backends.NotFoundErr {
+		notFoundHandler(c, w, r)
+		return
+	} else if err != nil {
+		oopsHandler(c, w, r, RespAUTO, "Unable to open file.")
+		return
 	}
 
 	w.Header().Set("Content-Type", metadata.Mimetype)


### PR DESCRIPTION
With the localfs backend, it's possible for a file to be removed but its
metadata file to remain intact. In this case, viewing the selif URL for
that file would return a broken page with two error pages stacked on top
of each other. This changes fixes that by replacing the output in that
case with a single "Unable to open file." error message.