### PR TITLE
Fix PutMetadata with S3 backend

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -148,10 +148,11 @@ func (b S3Backend) Put(key string, r io.Reader, expiry time.Time, deleteKey stri
 
 func (b S3Backend) PutMetadata(key string, m backends.Metadata) (err error) {
 	_, err = b.svc.CopyObject(&s3.CopyObjectInput{
-		Bucket:     aws.String(b.bucket),
-		Key:        aws.String(key),
-		CopySource: aws.String("/" + b.bucket + "/" + key),
-		Metadata:   mapMetadata(m),
+		Bucket:            aws.String(b.bucket),
+		Key:               aws.String(key),
+		CopySource:        aws.String("/" + b.bucket + "/" + key),
+		Metadata:          mapMetadata(m),
+		MetadataDirective: aws.String("REPLACE"),
 	})
 	if err != nil {
 		return


### PR DESCRIPTION
It turns out that the S3 API expects the additional `MetadataDirective:
REPLACE` option in order to update metadata. If this is not provided,
then metadata will simply be copied from the source object, which is not
what we wanted.