### PR TITLE
Fix S3 uploads

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -122,7 +122,12 @@ func (b S3Backend) Put(key string, r io.Reader, expiry time.Time, deleteKey stri
 		return m, err
 	}
 
-	m, err = helpers.GenerateMetadata(r)
+	_, err = tmpDst.Seek(0, 0)
+	if err != nil {
+		return m, err
+	}
+
+	m, err = helpers.GenerateMetadata(tmpDst)
 	if err != nil {
 		return
 	}
@@ -130,6 +135,11 @@ func (b S3Backend) Put(key string, r io.Reader, expiry time.Time, deleteKey stri
 	m.DeleteKey = deleteKey
 	// XXX: we may not be able to write this to AWS easily
 	//m.ArchiveFiles, _ = helpers.ListArchiveFiles(m.Mimetype, m.Size, tmpDst)
+
+	_, err = tmpDst.Seek(0, 0)
+	if err != nil {
+		return m, err
+	}
 
 	uploader := s3manager.NewUploaderWithClient(b.svc)
 	input := &s3manager.UploadInput{


### PR DESCRIPTION
My previous change that reworked how metadata generation worked was not
correct for two reasons:

* It passed the original `io.Reader` (with no bytes remaining) to
  `GenerateMetadata`
* It did not seek back to the beginning of the temporary file after
  writing to it, causing any subsequent reads to return EOF.

This change fixes both issues and S3 uploads now work fine. We really
ought to investigate adding test coverage to our S3 backend to avoid
similar recurrences.