### PR TITLE
Allow Basic authentication in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ allowhotlink = true
 #### Require API Keys for uploads
 - ```-authfile path/to/authfile``` -- (optionally) require authorization for upload/delete by providing a newline-separated file of scrypted auth keys
 - ```-remoteauthfile path/to/remoteauthfile``` -- (optionally) require authorization for remote uploads by providing a newline-separated file of scrypted auth keys
+- ```-basicauth``` -- (optionally) allow basic authorization to upload or paste files from browser when `-authfile` is enabled
 
 A helper utility ```linx-genkey``` is provided which hashes keys to the format required in the auth files.
 

--- a/auth.go
+++ b/auth.go
@@ -9,6 +9,8 @@ import (
 	"os"
 
 	"golang.org/x/crypto/scrypt"
+
+	"github.com/zenazn/goji/web"
 )
 
 const (
@@ -95,8 +97,8 @@ func (a auth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.successHandler.ServeHTTP(w, r)
 }
 
-func UploadAuth(o AuthOptions) func(http.Handler) http.Handler {
-	fn := func(h http.Handler) http.Handler {
+func UploadAuth(o AuthOptions) func(*web.C, http.Handler) http.Handler {
+	fn := func(c *web.C, h http.Handler) http.Handler {
 		return auth{
 			successHandler: h,
 			failureHandler: http.HandlerFunc(badAuthorizationHandler),

--- a/server.go
+++ b/server.go
@@ -190,6 +190,27 @@ func setup() *web.Mux {
 		}
 	}
 
+	if Config.basicAuth {
+		options := AuthOptions{
+			AuthFile:      Config.authFile,
+			UnauthMethods: []string{},
+		}
+		okFunc := func (w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", Config.sitePath)
+			w.WriteHeader(http.StatusFound)
+		}
+		authHandler := auth {
+			successHandler: http.HandlerFunc(okFunc),
+			failureHandler: http.HandlerFunc(badAuthorizationHandler),
+			authKeys:       readAuthKeys(Config.authFile),
+			o:              options,
+		}
+		mux.Head(Config.sitePath+"auth", authHandler)
+		mux.Head(Config.sitePath+"auth/", authHandler)
+		mux.Get(Config.sitePath+"auth", authHandler)
+		mux.Get(Config.sitePath+"auth/", authHandler)
+	}
+
 	mux.Post(Config.sitePath+"upload", uploadPostHandler)
 	mux.Post(Config.sitePath+"upload/", uploadPostHandler)
 	mux.Put(Config.sitePath+"upload", uploadPutHandler)

--- a/server.go
+++ b/server.go
@@ -59,6 +59,7 @@ var Config struct {
 	allowHotlink              bool
 	fastcgi                   bool
 	remoteUploads             bool
+	basicAuth                 bool
 	authFile                  string
 	remoteAuthFile            string
 	addHeaders                headerList
@@ -168,7 +169,7 @@ func setup() *web.Mux {
 	selifIndexRe := regexp.MustCompile("^" + Config.sitePath + Config.selifPath + `$`)
 	torrentRe := regexp.MustCompile("^" + Config.sitePath + `(?P<name>[a-z0-9-\.]+)/torrent$`)
 
-	if Config.authFile == "" {
+	if Config.authFile == "" || Config.basicAuth {
 		mux.Get(Config.sitePath, indexHandler)
 		mux.Get(Config.sitePath+"paste/", pasteHandler)
 	} else {
@@ -217,6 +218,8 @@ func main() {
 		"path to files directory")
 	flag.StringVar(&Config.metaDir, "metapath", "meta/",
 		"path to metadata directory")
+	flag.BoolVar(&Config.basicAuth, "basicauth", false,
+		"allow logging by basic auth password")
 	flag.BoolVar(&Config.noLogs, "nologs", false,
 		"remove stdout output for each request")
 	flag.BoolVar(&Config.allowHotlink, "allowhotlink", false,

--- a/templates.go
+++ b/templates.go
@@ -85,6 +85,7 @@ func renderTemplate(tpl *pongo2.Template, context pongo2.Context, r *http.Reques
 	context["sitepath"] = Config.sitePath
 	context["selifpath"] = Config.selifPath
 	context["using_auth"] = Config.authFile != ""
+	context["basic_auth"] = Config.basicAuth
 
 	return tpl.ExecuteWriter(context, writer)
 }

--- a/templates.go
+++ b/templates.go
@@ -84,8 +84,15 @@ func renderTemplate(tpl *pongo2.Template, context pongo2.Context, r *http.Reques
 
 	context["sitepath"] = Config.sitePath
 	context["selifpath"] = Config.selifPath
-	context["using_auth"] = Config.authFile != ""
-	context["basic_auth"] = Config.basicAuth
+	var a string
+	if Config.authFile == "" {
+		a = "none"
+	} else if Config.basicAuth {
+		a = "basic"
+	} else {
+		a = "header"
+	}
+	context["auth"] = a
 
 	return tpl.ExecuteWriter(context, writer)
 }

--- a/templates/API.html
+++ b/templates/API.html
@@ -14,7 +14,7 @@
 			<h3>Client</h3>
 			<p>To simplify uploading and deleting files, you can use <a target="_blank" href="https://github.com/andreimarcu/linx-client">linx-client</a>, which uses this API.</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<h3>Keys</h3>
 			<p>This instance uses API Keys, therefore you will need to provide a key for uploading and deleting files.<br/> To do so, add the <code>Linx-Api-Key</code> header with your key.</p>
 			{% endif %}
@@ -56,7 +56,7 @@
 
 			<p>Uploading myphoto.jpg</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<pre><code>$ curl -H &#34;Linx-Api-Key: mysecretkey&#34; -T myphoto.jpg {{ siteurl }}upload/  
 {{ siteurl }}{% if not forcerandom %}myphoto.jpg{% else %}7z4h4ut.jpg{% endif %}</code></pre>
 			{% else %}
@@ -66,7 +66,7 @@
 
 			<p>Uploading myphoto.jpg with an expiry of 20 minutes</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<pre><code>$ curl -H &#34;Linx-Api-Key: mysecretkey&#34; -H &#34;Linx-Expiry: 1200&#34; -T myphoto.jpg {{ siteurl }}upload/
 {{ siteurl }}{% if not forcerandom %}myphoto.jpg{% else %}jm295snf.jpg{% endif %}</code></pre>
 			{% else %}
@@ -76,7 +76,7 @@
 
 			<p>Uploading myphoto.jpg with a random filename and getting a json response:</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<pre><code>$ curl -H &#34;Linx-Api-Key: mysecretkey&#34; -H &#34;Accept: application/json&#34;{% if not forcerandom %} -H &#34;Linx-Randomize: yes&#34;{% endif %} -T myphoto.jpg {{ siteurl }}upload/  
 {&#34;delete_key&#34;:&#34;...&#34;,&#34;expiry&#34;:&#34;0&#34;,&#34;filename&#34;:&#34;f34h4iu.jpg&#34;,&#34;mimetype&#34;:&#34;image/jpeg&#34;,
 &#34;sha256sum&#34;:&#34;...&#34;,&#34;size&#34;:&#34;...&#34;,&#34;url&#34;:&#34;{{ siteurl }}f34h4iu.jpg&#34;}</code></pre>
@@ -94,7 +94,7 @@
 
 			<p>To overwrite myphoto.jpg</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<pre><code>$ curl -H &#34;Linx-Api-Key: mysecretkey&#34; -H &#34;Linx-Delete-Key: mysecret&#34; -T myphoto.jpg {{ siteurl }}upload/
 {{ siteurl }}myphoto.jpg</code></pre>
 			{% else %}
@@ -110,7 +110,7 @@
 
 			<p>To delete myphoto.jpg</p>
 
-			{% if using_auth %}
+			{% if auth != "none" %}
 			<pre><code>$ curl -H &#34;Linx-Api-Key: mysecretkey&#34; -H &#34;Linx-Delete-Key: mysecret&#34; -X DELETE {{ siteurl }}myphoto.jpg
 DELETED</code></pre>
 			{% else %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
 		<div id="container">
 			<div id="header">
 				<div id="navigation" class="right">
-					{% if !using_auth %}
+					{% if !using_auth || basic_auth %}
 					<a href="{{ sitepath }}">Upload</a> | 
 					<a href="{{ sitepath }}paste/">Paste</a> | 
 					{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
 		<div id="container">
 			<div id="header">
 				<div id="navigation" class="right">
-					{% if !using_auth || basic_auth %}
+					{% if auth != "header" %}
 					<a href="{{ sitepath }}">Upload</a> | 
 					<a href="{{ sitepath }}paste/">Paste</a> | 
 					{% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 
 {% block content %} 
 <div id="fileupload">
-    <form action="{{ sitepath }}upload" class="dropzone" id="dropzone" method="POST" enctype="multipart/form-data" data-maxsize="{{ maxsize }}">
+    <form action="{{ sitepath }}upload" class="dropzone" id="dropzone" method="POST" enctype="multipart/form-data" data-maxsize="{{ maxsize }}" data-auth="{{ auth }}">
         <div class="fallback">
             <input id="fileinput" name="file" type="file" /><br />
             <input id="submitbtn" type="submit" value="Upload">

--- a/upload.go
+++ b/upload.go
@@ -157,9 +157,20 @@ func uploadPutHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 
 func uploadRemote(c web.C, w http.ResponseWriter, r *http.Request) {
 	if Config.remoteAuthFile != "" {
-		result, err := checkAuth(remoteAuthKeys, r.FormValue("key"))
+		key := r.FormValue("key")
+		if key == "" && Config.basicAuth {
+			_, password, ok := r.BasicAuth()
+			if ok {
+				key = password
+			}
+		}
+		result, err := checkAuth(remoteAuthKeys, key)
 		if err != nil || !result {
-			unauthorizedHandler(c, w, r)
+			if Config.basicAuth {
+				badAuthorizationHandler(w, r)
+			} else {
+				unauthorizedHandler(c, w, r)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Fix for #88

This change allows setting new command line option `-basicauth` that allows sending files to authfile-enabled servers through browser.
When this option is enabled, upload and paste page is shown even when `-authfile` option is present. After either uploading a file, or pasting text, an standard browser authentication window is shown. Username is ignored, and password is taken as Api-Key. If the password match entry in authfile, upload or paste is allowed. If not, it fails with Unauthorized message.
Because browsers typically keep `Authorization` header, successive uploads don't require another password entry.

Unfortunately, there's no indication for user that password is the field for api key.

Please note that I do not have any experience in Go, and this was mostly done by reverse engineering already existing code. I tried to keep the changes as small as possible and everything should work as before if new command line options is not passed. I will be more than happy for guidance or tips how to improve the solution, or just straight up amends, if this is not adequate.