### PR TITLE
Add mime-type and extension handling for SVG files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/dustin/go-humanize v1.0.0
 	github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4
+	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/minio/sha256-simd v0.1.1
 	github.com/russross/blackfriday v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nI
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c h1:fEE5/5VNnYUoBOj2I9TP8Jc+a7lge3QWn9DKE7NCwfc=
+github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c/go.mod h1:ObS/W+h8RYb1Y7fYivughjxojTmIu5iAIjSrSLCLeqE=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/andreimarcu/linx-server/backends"
+	svg "github.com/h2non/go-is-svg"
 	"github.com/minio/sha256-simd"
 	"gopkg.in/h2non/filetype.v1"
 )
@@ -21,7 +22,7 @@ func GenerateMetadata(r io.Reader) (m backends.Metadata, err error) {
 
 	// Get first 512 bytes for mimetype detection
 	header := make([]byte, 512)
-	_, err = teeReader.Read(header)
+	headerlen, err := teeReader.Read(header)
 	if err != nil {
 		return
 	}
@@ -53,6 +54,8 @@ func GenerateMetadata(r io.Reader) (m backends.Metadata, err error) {
 		return m, err
 	} else if kind.MIME.Value != "" {
 		m.Mimetype = kind.MIME.Value
+	} else if svg.Is(header[:headerlen]) {
+		m.Mimetype = "image/svg+xml"
 	} else if printable(header) {
 		m.Mimetype = "text/plain"
 	} else {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -27,3 +27,24 @@ func TestGenerateMetadata(t *testing.T) {
 		t.Fatalf("Size was %d instead of expected value of %d", m.Size, expectedSize)
 	}
 }
+
+func TestSVGMimetype(t *testing.T) {
+	testcases := []struct {
+		mimetype  string
+		inputdata string
+	}{
+		{mimetype: "image/svg+xml", inputdata: "<svg width=\"2042pt\" height=\"810pt\">\nsvg things\n</svg>\n"},
+		{mimetype: "text/plain", inputdata: "Not an SVG!\nThis is sooo not an SVG file.\n"},
+	}
+
+	for i, record := range testcases {
+		r := strings.NewReader(record.inputdata)
+		m, err := GenerateMetadata(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.mimetype != m.Mimetype {
+			t.Fatalf("[svg testcase %d] Mimetype was %s instead of expected value %s", i, m.Mimetype, record.mimetype)
+		}
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1303,3 +1303,21 @@ func TestPutAndGetCLI(t *testing.T) {
 	}
 
 }
+
+func TestSVGExtension(t *testing.T) {
+	testcases := []struct {
+		extension string
+		inputdata string
+	}{
+		{extension: "svg", inputdata: "<svg width=\"2042pt\" height=\"810pt\">\nsvg things\n</svg>\n"},
+		{extension: "file", inputdata: "Not an SVG!\nThis is sooo not an SVG file.\n"},
+	}
+
+	for i, record := range testcases {
+		header := []byte(record.inputdata)
+		extension := determineExtension(header)
+		if record.extension != extension {
+			t.Fatalf("[svg testcase %d] extension was %s instead of expected value %s", i, extension, record.extension)
+		}
+	}
+}


### PR DESCRIPTION
SVG files get a mime-type of image/svg+xml.
SVG files with no filename get an extension of .svg.

Fixes #229