### PR TITLE
Add support for master delete IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ maxexpiry = 86400
 | ```nologs = true``` | (optionally) disable request logs in stdout
 | ```force-random-filename = true``` | (optionally) force the use of random filenames
 | ```custompagespath = custom_pages/``` | (optionally) specify path to directory containing markdown pages (must end in .md) that will be added to the site navigation (this can be useful for providing contact/support information and so on). For example, custom_pages/My_Page.md will become My Page in the site navigation 
+| ```delete-master-ip = 127.0.0.1``` | Comma-separated whitelist of master IP addresses that can delete any upload (Make sure IP addresses are being detected correctly before you enable this)
 
 
 #### Cleaning up expired files

--- a/delete.go
+++ b/delete.go
@@ -3,14 +3,13 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/andreimarcu/linx-server/backends"
 	"github.com/zenazn/goji/web"
 )
 
 func deleteHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	requestKey := r.Header.Get("Linx-Delete-Key")
-
 	filename := c.URLParams["name"]
 
 	// Ensure that file exists and delete key is correct
@@ -23,7 +22,7 @@ func deleteHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if metadata.DeleteKey == requestKey {
+	if deleteAllowed(r, metadata) {
 		err := storageBackend.Delete(filename)
 		if err != nil {
 			oopsHandler(c, w, r, RespPLAIN, "Could not delete")
@@ -37,4 +36,28 @@ func deleteHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 		unauthorizedHandler(c, w, r) // 401 - wrong delete key
 		return
 	}
+}
+
+func deleteAllowed(r *http.Request, metadata backends.Metadata) bool {
+	requestKey := r.Header.Get("Linx-Delete-Key")
+	if metadata.DeleteKey == requestKey {
+		return true
+	}
+
+	if Config.masterDeleteIp != "" {
+		whitelist := strings.Split(Config.masterDeleteIp, ",")
+		return remoteAddrInWhitelist(r, whitelist)
+	}
+
+	return false
+}
+
+func remoteAddrInWhitelist(r *http.Request, whitelist []string) bool {
+	remoteAddr := strings.SplitN(r.RemoteAddr, ":", 2)[0]
+	for _, ip := range whitelist {
+		if ip == remoteAddr {
+			return true
+		}
+	}
+	return false
 }

--- a/server.go
+++ b/server.go
@@ -74,6 +74,7 @@ var Config struct {
 	accessKeyCookieExpiry     uint64
 	customPagesDir            string
 	cleanupEveryMinutes       uint64
+	masterDeleteIp            string
 }
 
 var Templates = make(map[string]*pongo2.Template)
@@ -304,6 +305,8 @@ func main() {
 		"path to directory containing .md files to render as custom pages")
 	flag.Uint64Var(&Config.cleanupEveryMinutes, "cleanup-every-minutes", 0,
 		"How often to clean up expired files in minutes (default is 0, which means files will be cleaned up as they are accessed)")
+	flag.StringVar(&Config.masterDeleteIp, "master-delete-ip", "",
+		"Comma-separated whitelist of master IP addresses that can delete any upload (Make sure IP addresses are being detected correctly before you enable this)")
 
 	iniflags.Parse()
 


### PR DESCRIPTION
This PR adds support for master delete IP addresses. A address (Or multiple addresses separated by a comma) can be added to the config as `master-delete-ip`, and that IP will be able to delete an upload without requiring the delete key.