### PR TITLE
Remove entrypoint from sample docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ services:
   linx-server:
     container_name: linx-server
     image: andreimarcu/linx-server
-    entrypoint: /usr/local/bin/linx-server 
     command: -config /data/linx-server.conf
     volumes:
       - /path/to/files:/data/files


### PR DESCRIPTION
Resolves #225

Entrypoint in Dockerfile specifies default bind, filespath, metapath.
Having entrypoint in docker-compose.yml will remove those defaults.
Without the entrypoint line, the command executed is:
`/usr/local/bin/linx-server -bind=0.0.0.0:8080 -filespath=/data/files/ -metapath=/data/meta/ -config /data/linx-server.conf`